### PR TITLE
Guard admin helper against missing admin method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,6 @@ class ApplicationController < ActionController::Base
   helper_method :admin_signed_in?
 
   def admin_signed_in?
-    current_user&.admin?
+    current_user.respond_to?(:admin?) && current_user.admin?
   end
 end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  test "admin_signed_in? returns false when user lacks admin method" do
+    controller = ApplicationController.new
+    user = User.new
+    controller.stub :current_user, user do
+      assert_not controller.admin_signed_in?
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- guard ApplicationController#admin_signed_in? against missing admin? method
- add test covering admin_signed_in? behavior when user lacks admin method

## Testing
- `bundle exec rails test` *(fails: command not found: bundle)*

------
https://chatgpt.com/codex/tasks/task_e_689a4f57609c8331bfeb4d78ebdd6bc9